### PR TITLE
Rename package

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -2,7 +2,7 @@
   "$schema": "https://unpkg.com/@changesets/config@1.6.3/schema.json",
   "changelog": [
     "@changesets/changelog-github",
-    { "repo": "apollographql/operation-registry-plugin" }
+    { "repo": "apollographql/server-plugin-operation-registry" }
   ],
   "commit": false,
   "access": "public",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
-# @apollo/operation-registry-plugin
+# @apollo/server-plugin-operation-registry
 
 ## 3.5.2
 ### Patch Changes
 
 
 
-- [#1](https://github.com/apollographql/operation-registry-plugin/pull/1) [`f2521b4`](https://github.com/apollographql/operation-registry-plugin/commit/f2521b4c418572c76cb959d3c663b075e7707b82) Thanks [@joel-burton](https://github.com/joel-burton)! - initial publish of migrated package
+- [#1](https://github.com/apollographql/server-plugin-operation-registry/pull/1) [`f2521b4`](https://github.com/apollographql/server-plugin-operation-registry/commit/f2521b4c418572c76cb959d3c663b075e7707b82) Thanks [@joel-burton](https://github.com/joel-burton)! - initial publish of migrated package

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "@apollo/operation-registry-plugin",
+  "name": "@apollo/server-plugin-operation-registry",
   "version": "3.5.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "@apollo/operation-registry-plugin",
+      "name": "@apollo/server-plugin-operation-registry",
       "version": "3.5.2",
       "hasInstallScript": true,
       "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,16 +1,16 @@
 {
-  "name": "@apollo/operation-registry-plugin",
-  "description": "Apollo Server operation registry",
+  "name": "@apollo/server-plugin-operation-registry",
+  "description": "Apollo Server operation registry plugin",
   "version": "3.5.2",
   "author": "Apollo <packages@apollographql.com>",
   "repository": {
     "type": "git",
-    "url": "apollographql/operation-registry-plugin"
+    "url": "apollographql/server-plugin-operation-registry"
   },
   "license": "MIT",
-  "homepage": "https://github.com/apollographql/operation-registry-plugin#readme",
+  "homepage": "https://github.com/apollographql/server-plugin-operation-registry#readme",
   "bugs": {
-    "url": "https://github.com/apollographql/operation-registry-plugin/issues"
+    "url": "https://github.com/apollographql/server-plugin-operation-registry/issues"
   },
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
Renaming `@apollo/operation-registry-plugin` -> `@apollo/server-plugin-operation-registry`.

This change incorporates `server` into the name and also provides us a consistent prefix for other plugins to follow.

I _expect_ this to trigger an npm release when it lands - changeset should look for this new package name and publish since it doesn't see one. If not, I will follow with a patch changeset to trigger one for sure.