### PR TITLE
fix: Order of operations error when resolving manifest and storage secret urls

### DIFF
--- a/.changeset/swift-fishes-appear.md
+++ b/.changeset/swift-fishes-appear.md
@@ -1,0 +1,5 @@
+---
+"@apollo/server-plugin-operation-registry": patch
+---
+
+Fix an order of operations error when resolving the manifest and storage secret base URLs

--- a/src/__tests__/common.test.ts
+++ b/src/__tests__/common.test.ts
@@ -4,81 +4,81 @@ describe('common', () => {
   it('uses the correct cache prefix', () => {
     expect(common.getStoreKey('abc123')).toStrictEqual('abc123');
   });
-  
+
   describe('urlOperationManifestBase', () => {
-     const OLD_ENV = process.env;
-     beforeEach(() => {
-       jest.resetModules();
-       process.env = { ...OLD_ENV };
-     });
-     afterAll(() => {
-       process.env = OLD_ENV;
-     });
+    const OLD_ENV = process.env;
+    beforeEach(() => {
+      jest.resetModules();
+      process.env = { ...OLD_ENV };
+    });
+    afterAll(() => {
+      process.env = OLD_ENV;
+    });
 
-     it('evaluates to the override url when overridden', () => {
-       process.env.APOLLO_OPERATION_MANIFEST_BASE_URL = 'override';
-       const { urlOperationManifestBase } = require('../common');
-       expect(urlOperationManifestBase).toStrictEqual('override');
-     });
+    it('evaluates to the override url when overridden', () => {
+      process.env.APOLLO_OPERATION_MANIFEST_BASE_URL = 'override';
+      const { urlOperationManifestBase } = require('../common');
+      expect(urlOperationManifestBase).toStrictEqual('override');
+    });
 
-     it('removes trailing slashes from the override url when overridden', () => {
-       process.env.APOLLO_OPERATION_MANIFEST_BASE_URL = 'override/';
-       const { urlOperationManifestBase } = require('../common');
-       expect(urlOperationManifestBase).toStrictEqual('override');
-     });
+    it('removes trailing slashes from the override url when overridden', () => {
+      process.env.APOLLO_OPERATION_MANIFEST_BASE_URL = 'override/';
+      const { urlOperationManifestBase } = require('../common');
+      expect(urlOperationManifestBase).toStrictEqual('override');
+    });
 
-     it('evaluates to the test url when testing', () => {
-       process.env.__APOLLO_OPERATION_REGISTRY_TESTS__ = 'true';
-       const {
-         urlOperationManifestBase,
-         fakeTestBaseUrl,
-       } = require('../common');
-       expect(urlOperationManifestBase).toStrictEqual(fakeTestBaseUrl);
-     });
+    it('evaluates to the test url when testing', () => {
+      process.env.__APOLLO_OPERATION_REGISTRY_TESTS__ = 'true';
+      const {
+        urlOperationManifestBase,
+        fakeTestBaseUrl,
+      } = require('../common');
+      expect(urlOperationManifestBase).toStrictEqual(fakeTestBaseUrl);
+    });
 
-     it('evaluates to the default value when not overridden or testing', () => {
-       process.env.__APOLLO_OPERATION_REGISTRY_TESTS__ = 'false';
-       const { urlOperationManifestBase } = require('../common');
-       expect(urlOperationManifestBase).toStrictEqual(
-         'https://operations.api.apollographql.com',
-       );
-     });
-   });
+    it('evaluates to the default value when not overridden or testing', () => {
+      process.env.__APOLLO_OPERATION_REGISTRY_TESTS__ = 'false';
+      const { urlOperationManifestBase } = require('../common');
+      expect(urlOperationManifestBase).toStrictEqual(
+        'https://operations.api.apollographql.com',
+      );
+    });
+  });
 
-   describe('urlStorageSecretBase', () => {
-     const OLD_ENV = process.env;
-     beforeEach(() => {
-       jest.resetModules();
-       process.env = { ...OLD_ENV };
-     });
-     afterAll(() => {
-       process.env = OLD_ENV;
-     });
+  describe('urlStorageSecretBase', () => {
+    const OLD_ENV = process.env;
+    beforeEach(() => {
+      jest.resetModules();
+      process.env = { ...OLD_ENV };
+    });
+    afterAll(() => {
+      process.env = OLD_ENV;
+    });
 
-     it('evaluates to the override url when overridden', () => {
-       process.env.APOLLO_STORAGE_SECRET_BASE_URL = 'override';
-       const { urlStorageSecretBase } = require('../common');
-       expect(urlStorageSecretBase).toStrictEqual('override');
-     });
+    it('evaluates to the override url when overridden', () => {
+      process.env.APOLLO_STORAGE_SECRET_BASE_URL = 'override';
+      const { urlStorageSecretBase } = require('../common');
+      expect(urlStorageSecretBase).toStrictEqual('override');
+    });
 
-     it('removes trailing slashes from the override url when overridden', () => {
-       process.env.APOLLO_STORAGE_SECRET_BASE_URL = 'override/';
-       const { urlStorageSecretBase } = require('../common');
-       expect(urlStorageSecretBase).toStrictEqual('override');
-     });
+    it('removes trailing slashes from the override url when overridden', () => {
+      process.env.APOLLO_STORAGE_SECRET_BASE_URL = 'override/';
+      const { urlStorageSecretBase } = require('../common');
+      expect(urlStorageSecretBase).toStrictEqual('override');
+    });
 
-     it('evaluates to the test url when testing', () => {
-       process.env.__APOLLO_OPERATION_REGISTRY_TESTS__ = 'true';
-       const { urlStorageSecretBase, fakeTestBaseUrl } = require('../common');
-       expect(urlStorageSecretBase).toStrictEqual(fakeTestBaseUrl);
-     });
+    it('evaluates to the test url when testing', () => {
+      process.env.__APOLLO_OPERATION_REGISTRY_TESTS__ = 'true';
+      const { urlStorageSecretBase, fakeTestBaseUrl } = require('../common');
+      expect(urlStorageSecretBase).toStrictEqual(fakeTestBaseUrl);
+    });
 
-     it('evaluates to the default value when not overridden or testing', () => {
-       process.env.__APOLLO_OPERATION_REGISTRY_TESTS__ = 'false';
-       const { urlStorageSecretBase } = require('../common');
-       expect(urlStorageSecretBase).toStrictEqual(
-         'https://storage-secrets.api.apollographql.com',
-       );
-     });
-   });
+    it('evaluates to the default value when not overridden or testing', () => {
+      process.env.__APOLLO_OPERATION_REGISTRY_TESTS__ = 'false';
+      const { urlStorageSecretBase } = require('../common');
+      expect(urlStorageSecretBase).toStrictEqual(
+        'https://storage-secrets.api.apollographql.com',
+      );
+    });
+  });
 });

--- a/src/__tests__/common.test.ts
+++ b/src/__tests__/common.test.ts
@@ -4,4 +4,81 @@ describe('common', () => {
   it('uses the correct cache prefix', () => {
     expect(common.getStoreKey('abc123')).toStrictEqual('abc123');
   });
+  
+  describe('urlOperationManifestBase', () => {
+     const OLD_ENV = process.env;
+     beforeEach(() => {
+       jest.resetModules();
+       process.env = { ...OLD_ENV };
+     });
+     afterAll(() => {
+       process.env = OLD_ENV;
+     });
+
+     it('evaluates to the override url when overridden', () => {
+       process.env.APOLLO_OPERATION_MANIFEST_BASE_URL = 'override';
+       const { urlOperationManifestBase } = require('../common');
+       expect(urlOperationManifestBase).toStrictEqual('override');
+     });
+
+     it('removes trailing slashes from the override url when overridden', () => {
+       process.env.APOLLO_OPERATION_MANIFEST_BASE_URL = 'override/';
+       const { urlOperationManifestBase } = require('../common');
+       expect(urlOperationManifestBase).toStrictEqual('override');
+     });
+
+     it('evaluates to the test url when testing', () => {
+       process.env.__APOLLO_OPERATION_REGISTRY_TESTS__ = 'true';
+       const {
+         urlOperationManifestBase,
+         fakeTestBaseUrl,
+       } = require('../common');
+       expect(urlOperationManifestBase).toStrictEqual(fakeTestBaseUrl);
+     });
+
+     it('evaluates to the default value when not overridden or testing', () => {
+       process.env.__APOLLO_OPERATION_REGISTRY_TESTS__ = 'false';
+       const { urlOperationManifestBase } = require('../common');
+       expect(urlOperationManifestBase).toStrictEqual(
+         'https://operations.api.apollographql.com',
+       );
+     });
+   });
+
+   describe('urlStorageSecretBase', () => {
+     const OLD_ENV = process.env;
+     beforeEach(() => {
+       jest.resetModules();
+       process.env = { ...OLD_ENV };
+     });
+     afterAll(() => {
+       process.env = OLD_ENV;
+     });
+
+     it('evaluates to the override url when overridden', () => {
+       process.env.APOLLO_STORAGE_SECRET_BASE_URL = 'override';
+       const { urlStorageSecretBase } = require('../common');
+       expect(urlStorageSecretBase).toStrictEqual('override');
+     });
+
+     it('removes trailing slashes from the override url when overridden', () => {
+       process.env.APOLLO_STORAGE_SECRET_BASE_URL = 'override/';
+       const { urlStorageSecretBase } = require('../common');
+       expect(urlStorageSecretBase).toStrictEqual('override');
+     });
+
+     it('evaluates to the test url when testing', () => {
+       process.env.__APOLLO_OPERATION_REGISTRY_TESTS__ = 'true';
+       const { urlStorageSecretBase, fakeTestBaseUrl } = require('../common');
+       expect(urlStorageSecretBase).toStrictEqual(fakeTestBaseUrl);
+     });
+
+     it('evaluates to the default value when not overridden or testing', () => {
+       process.env.__APOLLO_OPERATION_REGISTRY_TESTS__ = 'false';
+       const { urlStorageSecretBase } = require('../common');
+       expect(urlStorageSecretBase).toStrictEqual(
+         'https://storage-secrets.api.apollographql.com',
+       );
+     });
+   });
 });

--- a/src/common.ts
+++ b/src/common.ts
@@ -12,18 +12,18 @@ export const urlOperationManifestBase: string =
   // Remove trailing slash if any.
   process.env[envOverrideOperationManifest]?.replace(/\/$/, '') ||
   // See src/__tests__/jestSetup.ts for more details on this env. variable.
-  process.env['__APOLLO_OPERATION_REGISTRY_TESTS__'] === 'true'
+  (process.env['__APOLLO_OPERATION_REGISTRY_TESTS__'] === 'true'
     ? fakeTestBaseUrl
-    : 'https://operations.api.apollographql.com';
+    : 'https://operations.api.apollographql.com');
 
 // Generate and cache our desired storage secret URL.
 export const urlStorageSecretBase: string =
   // Remove trailing slash if any.
   process.env[envOverrideStorageSecretBaseUrl]?.replace(/\/$/, '') ||
   // See src/__tests__/jestSetup.ts for more details on this env. variable.
-  process.env['__APOLLO_OPERATION_REGISTRY_TESTS__'] === 'true'
+  (process.env['__APOLLO_OPERATION_REGISTRY_TESTS__'] === 'true'
     ? fakeTestBaseUrl
-    : 'https://storage-secrets.api.apollographql.com';
+    : 'https://storage-secrets.api.apollographql.com');
 
 export const getStoreKey = (signature: string) => `${signature}`;
 


### PR DESCRIPTION
(Moved from https://github.com/apollographql/apollo-server/pull/6125)

This fixes two order-of-operations issues, with the `urlOperationManifestBase` and `urlStorageSecretBase` constants, and adds tests for their behavior.

## Existing behavior:
If `process.env[envOverrideOperationManifest]?.replace(/\/$/, '')` evaluates to a truthy value, the hard-coded default test URL is used.
If `process.env[envOverrideStorageSecretBaseUrl]?.replace(/\/$/, '')` evaluates to a truthy value, the hard-coded default test URL is used.

## Expected behavior:
If `process.env[envOverrideOperationManifest]?.replace(/\/$/, '')` evaluates to a truthy value, the URL provided by `envOverrideOperationManifest` is used.
If `process.env[envOverrideStorageSecretBaseUrl]?.replace(/\/$/, '')` evaluates to a truthy value, the URL provided by `envOverrideStorageSecretBaseUrl` is used.