### PR TITLE
Remove `apollo-graphql` dependency

### DIFF
--- a/.changeset/plenty-steaks-rule.md
+++ b/.changeset/plenty-steaks-rule.md
@@ -1,0 +1,5 @@
+---
+'@apollo/server-plugin-operation-registry': patch
+---
+
+Remove the apollo-graphql dependency in favor of equivalent apollo-utils deps

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "apollo-graphql": "^0.9.5",
+        "@apollo/utils.createhash": "^1.1.0",
+        "@apollo/utils.operationregistrysignature": "^1.1.0",
         "apollo-server-caching": "^3.3.0",
         "apollo-server-env": "^4.2.1",
         "apollo-server-errors": "^3.3.1",
@@ -38,6 +39,9 @@
       },
       "engines": {
         "node": ">=12.0"
+      },
+      "peerDependencies": {
+        "graphql": "14.x || 15.x || 16.x"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -82,11 +86,22 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.60.tgz",
       "integrity": "sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw=="
     },
+    "node_modules/@apollo/utils.createhash": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@apollo/utils.createhash/-/utils.createhash-1.1.0.tgz",
+      "integrity": "sha512-5fT4ZiW75515OlikWpIQzaVDws1yy9VgYSoHoJCrvI2UH6/7YNKXQjbjT5qVYu6ytch2wBxFMfFfYWMn/2bSCQ==",
+      "dependencies": {
+        "@apollo/utils.isnodelike": "^1.1.0",
+        "sha.js": "^2.4.11"
+      },
+      "engines": {
+        "node": ">=12.13.0"
+      }
+    },
     "node_modules/@apollo/utils.dropunuseddefinitions": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@apollo/utils.dropunuseddefinitions/-/utils.dropunuseddefinitions-1.1.0.tgz",
       "integrity": "sha512-jU1XjMr6ec9pPoL+BFWzEPW7VHHulVdGKMkPAMiCigpVIT11VmCbnij0bWob8uS3ODJ65tZLYKAh/55vLw2rbg==",
-      "dev": true,
       "engines": {
         "node": ">=12.13.0"
       },
@@ -94,16 +109,37 @@
         "graphql": "14.x || 15.x || 16.x"
       }
     },
+    "node_modules/@apollo/utils.isnodelike": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@apollo/utils.isnodelike/-/utils.isnodelike-1.1.0.tgz",
+      "integrity": "sha512-q/Q82kBUSEcx1ED11JO1TYBY781mWluUnBD8NvhjHVsu1K1C5R9BZVUxShyK/V8XcePcRUB5fdWOcBMGwS0KOA==",
+      "engines": {
+        "node": ">=12.13.0"
+      }
+    },
     "node_modules/@apollo/utils.logger": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@apollo/utils.logger/-/utils.logger-1.0.0.tgz",
       "integrity": "sha512-dx9XrjyisD2pOa+KsB5RcDbWIAdgC91gJfeyLCgy0ctJMjQe7yZK5kdWaWlaOoCeX0z6YI9iYlg7vMPyMpQF3Q=="
     },
+    "node_modules/@apollo/utils.operationregistrysignature": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@apollo/utils.operationregistrysignature/-/utils.operationregistrysignature-1.1.0.tgz",
+      "integrity": "sha512-y728SsDfUZMSkZilKjA9Mj3Hv4jpY4hw0BeNVSC+ko3pRDJSA/0n92jlQWuTitSp7rBe+/eaqRA36bGPHP/D2g==",
+      "dependencies": {
+        "@apollo/utils.dropunuseddefinitions": "^1.1.0",
+        "@apollo/utils.printwithreducedwhitespace": "^1.1.0",
+        "@apollo/utils.sortast": "^1.1.0",
+        "@apollo/utils.stripsensitiveliterals": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=12.13.0"
+      }
+    },
     "node_modules/@apollo/utils.printwithreducedwhitespace": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@apollo/utils.printwithreducedwhitespace/-/utils.printwithreducedwhitespace-1.1.0.tgz",
       "integrity": "sha512-GfFSkAv3n1toDZ4V6u2d7L4xMwLA+lv+6hqXicMN9KELSJ9yy9RzuEXaX73c/Ry+GzRsBy/fdSUGayGqdHfT2Q==",
-      "dev": true,
       "engines": {
         "node": ">=12.13.0"
       },
@@ -127,7 +163,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@apollo/utils.sortast/-/utils.sortast-1.1.0.tgz",
       "integrity": "sha512-VPlTsmUnOwzPK5yGZENN069y6uUHgeiSlpEhRnLFYwYNoJHsuJq2vXVwIaSmts015WTPa2fpz1inkLYByeuRQA==",
-      "dev": true,
       "dependencies": {
         "lodash.sortby": "^4.7.0"
       },
@@ -142,7 +177,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@apollo/utils.stripsensitiveliterals/-/utils.stripsensitiveliterals-1.2.0.tgz",
       "integrity": "sha512-E41rDUzkz/cdikM5147d8nfCFVKovXxKBcjvLEQ7bjZm/cg9zEcXvS6vFY8ugTubI3fn6zoqo0CyU8zT+BGP9w==",
-      "dev": true,
       "engines": {
         "node": ">=12.13.0"
       },
@@ -2372,22 +2406,6 @@
         "node": ">=12.0"
       }
     },
-    "node_modules/apollo-graphql": {
-      "version": "0.9.5",
-      "resolved": "https://registry.npmjs.org/apollo-graphql/-/apollo-graphql-0.9.5.tgz",
-      "integrity": "sha512-RGt5k2JeBqrmnwRM0VOgWFiGKlGJMfmiif/4JvdaEqhMJ+xqe/9cfDYzXfn33ke2eWixsAbjEbRfy8XbaN9nTw==",
-      "dependencies": {
-        "core-js-pure": "^3.10.2",
-        "lodash.sortby": "^4.7.0",
-        "sha.js": "^2.4.11"
-      },
-      "engines": {
-        "node": ">=6"
-      },
-      "peerDependencies": {
-        "graphql": "^14.2.1 || ^15.0.0"
-      }
-    },
     "node_modules/apollo-reporting-protobuf": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/apollo-reporting-protobuf/-/apollo-reporting-protobuf-3.3.1.tgz",
@@ -3018,16 +3036,6 @@
       "dev": true,
       "dependencies": {
         "safe-buffer": "~5.1.1"
-      }
-    },
-    "node_modules/core-js-pure": {
-      "version": "3.21.1",
-      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.21.1.tgz",
-      "integrity": "sha512-12VZfFIu+wyVbBebyHmRTuEE/tZrB4tJToWcwAMcsp3h4+sHR+fMJWbKpYiCRWlhFBq+KNyO8rIV9rTkeVmznQ==",
-      "hasInstallScript": true,
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/core-js"
       }
     },
     "node_modules/create-require": {
@@ -8502,23 +8510,46 @@
         }
       }
     },
+    "@apollo/utils.createhash": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@apollo/utils.createhash/-/utils.createhash-1.1.0.tgz",
+      "integrity": "sha512-5fT4ZiW75515OlikWpIQzaVDws1yy9VgYSoHoJCrvI2UH6/7YNKXQjbjT5qVYu6ytch2wBxFMfFfYWMn/2bSCQ==",
+      "requires": {
+        "@apollo/utils.isnodelike": "^1.1.0",
+        "sha.js": "^2.4.11"
+      }
+    },
     "@apollo/utils.dropunuseddefinitions": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@apollo/utils.dropunuseddefinitions/-/utils.dropunuseddefinitions-1.1.0.tgz",
       "integrity": "sha512-jU1XjMr6ec9pPoL+BFWzEPW7VHHulVdGKMkPAMiCigpVIT11VmCbnij0bWob8uS3ODJ65tZLYKAh/55vLw2rbg==",
-      "dev": true,
       "requires": {}
+    },
+    "@apollo/utils.isnodelike": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@apollo/utils.isnodelike/-/utils.isnodelike-1.1.0.tgz",
+      "integrity": "sha512-q/Q82kBUSEcx1ED11JO1TYBY781mWluUnBD8NvhjHVsu1K1C5R9BZVUxShyK/V8XcePcRUB5fdWOcBMGwS0KOA=="
     },
     "@apollo/utils.logger": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@apollo/utils.logger/-/utils.logger-1.0.0.tgz",
       "integrity": "sha512-dx9XrjyisD2pOa+KsB5RcDbWIAdgC91gJfeyLCgy0ctJMjQe7yZK5kdWaWlaOoCeX0z6YI9iYlg7vMPyMpQF3Q=="
     },
+    "@apollo/utils.operationregistrysignature": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@apollo/utils.operationregistrysignature/-/utils.operationregistrysignature-1.1.0.tgz",
+      "integrity": "sha512-y728SsDfUZMSkZilKjA9Mj3Hv4jpY4hw0BeNVSC+ko3pRDJSA/0n92jlQWuTitSp7rBe+/eaqRA36bGPHP/D2g==",
+      "requires": {
+        "@apollo/utils.dropunuseddefinitions": "^1.1.0",
+        "@apollo/utils.printwithreducedwhitespace": "^1.1.0",
+        "@apollo/utils.sortast": "^1.1.0",
+        "@apollo/utils.stripsensitiveliterals": "^1.1.0"
+      }
+    },
     "@apollo/utils.printwithreducedwhitespace": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@apollo/utils.printwithreducedwhitespace/-/utils.printwithreducedwhitespace-1.1.0.tgz",
       "integrity": "sha512-GfFSkAv3n1toDZ4V6u2d7L4xMwLA+lv+6hqXicMN9KELSJ9yy9RzuEXaX73c/Ry+GzRsBy/fdSUGayGqdHfT2Q==",
-      "dev": true,
       "requires": {}
     },
     "@apollo/utils.removealiases": {
@@ -8532,7 +8563,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@apollo/utils.sortast/-/utils.sortast-1.1.0.tgz",
       "integrity": "sha512-VPlTsmUnOwzPK5yGZENN069y6uUHgeiSlpEhRnLFYwYNoJHsuJq2vXVwIaSmts015WTPa2fpz1inkLYByeuRQA==",
-      "dev": true,
       "requires": {
         "lodash.sortby": "^4.7.0"
       }
@@ -8541,7 +8571,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@apollo/utils.stripsensitiveliterals/-/utils.stripsensitiveliterals-1.2.0.tgz",
       "integrity": "sha512-E41rDUzkz/cdikM5147d8nfCFVKovXxKBcjvLEQ7bjZm/cg9zEcXvS6vFY8ugTubI3fn6zoqo0CyU8zT+BGP9w==",
-      "dev": true,
       "requires": {}
     },
     "@apollo/utils.usagereporting": {
@@ -10389,16 +10418,6 @@
         "apollo-server-env": "^4.2.1"
       }
     },
-    "apollo-graphql": {
-      "version": "0.9.5",
-      "resolved": "https://registry.npmjs.org/apollo-graphql/-/apollo-graphql-0.9.5.tgz",
-      "integrity": "sha512-RGt5k2JeBqrmnwRM0VOgWFiGKlGJMfmiif/4JvdaEqhMJ+xqe/9cfDYzXfn33ke2eWixsAbjEbRfy8XbaN9nTw==",
-      "requires": {
-        "core-js-pure": "^3.10.2",
-        "lodash.sortby": "^4.7.0",
-        "sha.js": "^2.4.11"
-      }
-    },
     "apollo-reporting-protobuf": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/apollo-reporting-protobuf/-/apollo-reporting-protobuf-3.3.1.tgz",
@@ -10893,11 +10912,6 @@
       "requires": {
         "safe-buffer": "~5.1.1"
       }
-    },
-    "core-js-pure": {
-      "version": "3.21.1",
-      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.21.1.tgz",
-      "integrity": "sha512-12VZfFIu+wyVbBebyHmRTuEE/tZrB4tJToWcwAMcsp3h4+sHR+fMJWbKpYiCRWlhFBq+KNyO8rIV9rTkeVmznQ=="
     },
     "create-require": {
       "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,8 @@
     "typescript": "4.7.2"
   },
   "dependencies": {
-    "apollo-graphql": "^0.9.5",
+    "@apollo/utils.createhash": "^1.1.0",
+    "@apollo/utils.operationregistrysignature": "^1.1.0",
     "apollo-server-caching": "^3.3.0",
     "apollo-server-env": "^4.2.1",
     "apollo-server-errors": "^3.3.1",
@@ -55,6 +56,9 @@
     "fast-json-stable-stringify": "^2.1.0",
     "loglevel": "^1.8.0",
     "make-fetch-happen": "^8.0.9"
+  },
+  "peerDependencies": {
+    "graphql": "14.x || 15.x || 16.x"
   },
   "volta": {
     "node": "16.15.0",

--- a/src/ApolloServerPluginOperationRegistry.ts
+++ b/src/ApolloServerPluginOperationRegistry.ts
@@ -1,4 +1,4 @@
-import { pluginName, getStoreKey, signatureForLogging } from './common';
+import { pluginName, getStoreKey, signatureForLogging, operationHash } from './common';
 import type {
   ApolloServerPlugin,
   GraphQLServiceContext,
@@ -6,17 +6,7 @@ import type {
   GraphQLRequestContext,
   GraphQLServerListener,
 } from 'apollo-server-plugin-base';
-import {
-  /**
-   * We alias these to different names entirely since the user-facing values
-   * which are present in their manifest (signature and document) are probably
-   * the most important concepts to rally around right now, in terms of
-   * approachability to the implementor.  A future version of the
-   * `apollo-graphql` package should rename them to make this more clear.
-   */
-  operationHash as operationSignature,
-  defaultOperationRegistrySignature as defaultOperationRegistryNormalization,
-} from 'apollo-graphql';
+import { operationRegistrySignature } from '@apollo/utils.operationregistrysignature';
 import { ForbiddenError, ApolloError } from 'apollo-server-errors';
 import Agent from './agent';
 import { InMemoryLRUCache } from 'apollo-server-caching';
@@ -151,7 +141,7 @@ for observability purposes, but all operations will be permitted.`,
             throw new Error('Unable to access store.');
           }
 
-          const normalizedDocument = defaultOperationRegistryNormalization(
+          const normalizedDocument = operationRegistrySignature(
             documentFromRequestContext,
 
             // XXX The `operationName` is set from the AST, not from the
@@ -167,7 +157,7 @@ for observability purposes, but all operations will be permitted.`,
             requestContext.operationName || '',
           );
 
-          const signature = operationSignature(normalizedDocument);
+          const signature = operationHash(normalizedDocument);
 
           if (!signature) {
             throw new ApolloError('No document.');

--- a/src/__tests__/ApolloServerPluginOperationRegistry.test.ts
+++ b/src/__tests__/ApolloServerPluginOperationRegistry.test.ts
@@ -3,18 +3,8 @@ import {
   ApolloServerBase,
   ApolloServerPluginUsageReportingDisabled,
 } from 'apollo-server-core';
-
-import {
-  /**
-   * We alias these to different names entirely since the user-facing values
-   * which are present in their manifest (signature and document) are probably
-   * the most important concepts to rally around right now, in terms of
-   * approachability to the implementor.  A future version of the
-   * `apollo-graphql` package should rename them to make this more clear.
-   */
-  defaultOperationRegistrySignature as defaultOperationRegistryNormalization,
-  operationHash as operationSignature,
-} from 'apollo-graphql';
+import { operationRegistrySignature } from '@apollo/utils.operationregistrysignature';
+import { operationHash } from '../common';
 import gql from 'graphql-tag';
 import { print } from 'graphql';
 import loglevel from 'loglevel';
@@ -80,11 +70,11 @@ describe('Operation registry plugin', () => {
       }
     `;
 
-    const normalizedQueryDocument = defaultOperationRegistryNormalization(
+    const normalizedQueryDocument = operationRegistrySignature(
       query,
       'HelloFam',
     );
-    const queryHash = operationSignature(normalizedQueryDocument);
+    const queryHash = operationHash(normalizedQueryDocument);
 
     describe('onUnregisterOperation', () => {
       it('is called when unregistered operation received', async () => {

--- a/src/common.ts
+++ b/src/common.ts
@@ -1,3 +1,5 @@
+import { createHash } from "@apollo/utils.createhash";
+
 export const pluginName: string = require('../package.json').name;
 
 export const envOverrideOperationManifest =
@@ -47,4 +49,8 @@ export function signatureForLogging(signature: string): string {
     return '<non-string>';
   }
   return signature.substring(0, 8);
+}
+
+export function operationHash(operation: string) {
+  return createHash("sha256").update(operation).digest("hex");
 }


### PR DESCRIPTION
This commit removes the apollo-graphql dependency, which doesn't
support graphql@^16 versions. We have equivalent functions in
the apollo-utils monorepo which don't have that limitation. This
change ought to have happened when those functions were originally
introduced, so the need for this change is completely expected.