### PR TITLE
Drop support for Node.js v12

### DIFF
--- a/.changeset/sour-donkeys-visit.md
+++ b/.changeset/sour-donkeys-visit.md
@@ -1,0 +1,5 @@
+---
+'@apollo/server-plugin-operation-registry': major
+---
+
+Drop support for Node.js v12

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,7 +60,6 @@ workflows:
           matrix:
             parameters:
               node-version:
-                - "12"
                 - "14"
                 - "16"
                 - "18"

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,6 @@
     "": {
       "name": "@apollo/server-plugin-operation-registry",
       "version": "3.5.6",
-      "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "@apollo/utils.createhash": "^1.1.0",
@@ -37,7 +36,7 @@
         "typescript": "4.8.4"
       },
       "engines": {
-        "node": ">=12.0"
+        "node": ">=14.0"
       },
       "peerDependencies": {
         "graphql": "14.x || 15.x || 16.x"

--- a/package.json
+++ b/package.json
@@ -15,13 +15,13 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "engines": {
-    "node": ">=12.0"
+    "node": ">=14.0"
   },
   "scripts": {
     "build": "tsc --build tsconfig.build.json",
     "clean": "git clean -dfqX",
     "install-with-npm-8.5": "npm i -g npm@^8.5.0 && npm i",
-    "postinstall": "npm run build",
+    "prepack": "npm run build",
     "prettier:check": "prettier --check .",
     "prettier:fix": "prettier --write .",
     "publish-changeset": "changeset publish",


### PR DESCRIPTION
Node.js v12 is EOL. Continuing to support and test against v12 is blocking major updates on this repo. So for multiple reasons, let's drop support for v12 and release a new major version.

Additionally, remove `postinstall` script (see https://github.com/apollographql/typescript-repo-template/pull/92 for more details).